### PR TITLE
Add missing comma in _meta.lua

### DIFF
--- a/_meta.lua
+++ b/_meta.lua
@@ -3,5 +3,5 @@ return {
     name = "filebrowserplus",
     fullname = _("FilebrowserPlus"),
     description = _([[Connect and transfer files to the device using the famous filebrowser.]]),
-    version = "1.0.2"
+    version = "1.0.3"
 }


### PR DESCRIPTION
There is a comma missing in _meta.lua which breaks compatibility with the Updates Manager plugin