### PR TITLE
Add Android support (noexec workaround, pid path, pipe fix, IP detection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,27 @@ That’s it — the plugin will automatically use the new binary.
 1. Open KOReader’s top menu.
 2. Make sure your device is connected to Wi-Fi.
 3. Go to **Gearbox Menu → Network → FilebrowserPlus**.
-4. Adjust the configuration as needed:
+4. Open **FilebrowserPlus settings** (long press on FilebrowserPlus entry) and adjust configuration as needed:
    - **Data path:** defaults to `/`.
      - Note: On **Kindle**, only directories within `/mnt/us` (including `/mnt/us` itself) are writable.
      - On **Kobo**, only directories within `/mnt/onboard` (including `/mnt/onboard` itself) are writable.
      - ⚠️ **Important:** Paths outside these locations are **read-only**, and attempting to use them will prevent directory creation and cause the server to fail to start.
    - **Port:** defaults to `80`. If you get a permission error, try another port such as `8080`.
-5. Start the server.
+   - **Auto-stop timeout (min):** defaults to `30`.
+     - Set to `0` to disable auto-stop.
+5. Start the server with a normal tap on **FilebrowserPlus**.
    - Default username: `admin`
-   - Default password: `admin12345678`
-6. When the server starts, you’ll see the **IP address and port**.  
+   - Default password: `admin12345678` (shown on first setup)
+6. When running, the menu label shows **IP:port** when available.  
    Visit that address (e.g., `http://192.168.x.x:8080`) from your phone or computer connected to the same Wi-Fi network.
 7. You can change the password or create new users via the Filebrowser web interface.
-8. If you ever forget your password, press **“Reset Admin Password”** in the plugin menu — it will reset it to the default.
+8. If you ever forget your password, press **“Reset Admin User Password”** in the plugin settings — it resets to default.
+
+## Menu behavior
+
+- **Tap** on `FilebrowserPlus`: start/stop server quickly.
+- **Long press** on `FilebrowserPlus`: open plugin settings.
+- While running, menu text shows current connection endpoint (`IP:port` when available).
 
 ## Why not use the existing [filebrowser.koplugin](https://github.com/b-/filebrowser.koplugin)?
 
@@ -73,6 +81,7 @@ Compared to the original plugin, FilebrowserPlus adds:
 - Reset admin password directly from KOReader
 - Configurable authentication (the original had auth disabled by default)
 - Option to auto-start with KOReader
+- Configurable auto-stop timeout (including disable option)
 
 ## Compatibility
 

--- a/_meta.lua
+++ b/_meta.lua
@@ -3,5 +3,5 @@ return {
     name = "filebrowserplus",
     fullname = _("FilebrowserPlus"),
     description = _([[Connect and transfer files to the device using the famous filebrowser.]]),
-    version = "1.1.0"
+    version = "1.2.0-pre"
 }

--- a/main.lua
+++ b/main.lua
@@ -8,6 +8,7 @@ local Dispatcher = require("dispatcher")
 local InfoMessage = require("ui/widget/infomessage") -- luacheck:ignore
 local InputDialog = require("ui/widget/inputdialog")
 local UIManager = require("ui/uimanager")
+local TouchMenu = require("ui/widget/touchmenu")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local ffiutil = require("ffi/util")
 local logger = require("logger")
@@ -51,10 +52,22 @@ function FilebrowserPlus:init()
     self.allow_no_password = G_reader_settings:isTrue("FilebrowserPlus_allow_no_password")
     self.autostart = G_reader_settings:isTrue("FilebrowserPlus_autostart")
     self.filebrowserplus_dataPath = G_reader_settings:readSetting("FilebrowserPlus_dataPath") or "/"
-
+    self.auto_stop_minutes = G_reader_settings:readSetting("FilebrowserPlus_auto_stop_minutes") or 30
+    self.auto_stop_task = function()
+        self:checkAutoStop()
+    end
+    self.auto_stop_scheduled = false
     if self.autostart then
         logger.info("[FilebrowserPlus] Autostart enabled, starting server on port " .. self.filebrowserplus_port)
         self:start()
+    end
+
+    -- Restore auto-stop timer if server is running (e.g. after KOReader restart)
+    -- This resets the timer to the full duration
+    if self:isRunning() and self.auto_stop_minutes > 0 and not self.auto_stop_scheduled then
+        logger.info("[FilebrowserPlus] Server found running, restoring auto-stop timer.")
+        self.stop_deadline = os.time() + (self.auto_stop_minutes * 60)
+        self:checkAutoStop()
     end
 
     self.ui.menu:registerToMainMenu(self)
@@ -169,42 +182,67 @@ function FilebrowserPlus:start()
     local status = os.execute(cmd)
 
     if status == 0 then
-        -- Try to get IP address only
-        local ip_info = ""
-        if Device.retrieveNetworkInfo then
-            local net_info = Device:retrieveNetworkInfo()
-            if type(net_info) == "table" and net_info.ip then
-                ip_info = net_info.ip
-            elseif type(net_info) == "string" then
-                -- In case the function returns a string (some devices do)
-                ip_info = net_info:match("(%d+%.%d+%.%d+%.%d+)") or _("Unknown IP")
-            else
-                ip_info = _("Unknown IP")
-            end
-        else
-            ip_info = _("Could not retrieve IP address.")
-        end
-
         -- Add default credentials if it's the first setup
         local extra_info = ""
+        local timeout_duration = 3
         if self.filebrowserplus_first_setup then
             extra_info = _("\n\nDefault username: admin\nDefault password: admin12345678")
+            timeout_duration = 15
+        end
+
+        local auto_stop_msg = ""
+        if self.auto_stop_minutes and self.auto_stop_minutes > 0 then
+            auto_stop_msg = "\n" .. T(_("Auto-stop in %1 min"), self.auto_stop_minutes)
         end
 
         local info = InfoMessage:new{
-            timeout = 15,
-            text = T(_("FilebrowserPlus server started.\n\nPort: %1\nIP Address: %2%3"), self.filebrowserplus_port,
-                ip_info, extra_info)
+            timeout = timeout_duration,
+            text = _("FilebrowserPlus server started.") .. auto_stop_msg .. extra_info
         }
         UIManager:show(info)
+        
+        -- Schedule auto-stop if configured
+        if self.auto_stop_minutes and self.auto_stop_minutes > 0 then
+            self.stop_deadline = os.time() + (self.auto_stop_minutes * 60)
+            self:checkAutoStop()
+            logger.info("[FilebrowserPlus] Auto-stop scheduled in " .. self.auto_stop_minutes .. " minutes (Deadline: " .. os.date("%c", self.stop_deadline) .. ").")
+        end
     else
         local info = InfoMessage:new{
             icon = "notice-warning",
-            text = _("Failed to start FilebrowserPlus server.")
+            timeout = 15,
+            text = _("Failed to start FilebrowserPlus server")
         }
         UIManager:show(info)
     end
 
+end
+
+function FilebrowserPlus:checkAutoStop()
+    if not self:isRunning() then
+        self.auto_stop_scheduled = false
+        return
+    end
+
+    if not self.stop_deadline then
+        self.auto_stop_scheduled = false
+        return
+    end
+
+    if os.time() >= self.stop_deadline then
+        logger.info("[FilebrowserPlus] Auto-stop timer expired, stopping server.")
+        self.auto_stop_scheduled = false
+        self:stop(true)
+        UIManager:show(InfoMessage:new{
+            text = _("FilebrowserPlus server auto-stopped after timeout"),
+            timeout = 3
+        })
+    else
+        local remaining = self.stop_deadline - os.time()
+        local next_check = math.min(60, math.max(1, remaining))
+        self.auto_stop_scheduled = true
+        UIManager:scheduleIn(next_check, self.auto_stop_task)
+    end
 end
 
 function FilebrowserPlus:isRunning()
@@ -236,7 +274,14 @@ function FilebrowserPlus:isRunning()
     end
 end
 
-function FilebrowserPlus:stop()
+function FilebrowserPlus:stop(is_auto)
+    -- Cancel auto-stop timer if running
+    if self.auto_stop_scheduled and self.auto_stop_task then
+        UIManager:unschedule(self.auto_stop_task)
+        self.auto_stop_scheduled = false
+    end
+    self.stop_deadline = nil    
+    
     local cmd = string.format("if [ -f '%s' ]; then kill $(cat '%s') 2>/dev/null; rm -f '%s'; fi", pid_path, pid_path,
         pid_path)
     logger.info("[FilebrowserPlus] Stopping Filebrowser:", cmd)
@@ -244,26 +289,28 @@ function FilebrowserPlus:stop()
 
     if status == 0 then
         logger.info("[FilebrowserPlus] Filebrowser stopped.")
-        UIManager:show(InfoMessage:new{
-            text = _("FilebrowserPlus server stopped."),
-            timeout = 2
-        })
+        if not is_auto then
+            UIManager:show(InfoMessage:new{
+                text = _("FilebrowserPlus server stopped."),
+                timeout = 3
+            })
+        end
 
         if Device:isKindle() then
-        os.execute(string.format("%s %s %s", "iptables -D INPUT -p tcp --dport", self.filebrowserplus_port,
-            "-m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT"))
-        os.execute(string.format("%s %s %s", "iptables -D OUTPUT -p tcp --sport", self.filebrowserplus_port,
-            "-m conntrack --ctstate ESTABLISHED -j ACCEPT"))
-    end
+            os.execute(string.format("%s %s %s", "iptables -D INPUT -p tcp --dport", self.filebrowserplus_port,
+                "-m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT"))
+            os.execute(string.format("%s %s %s", "iptables -D OUTPUT -p tcp --sport", self.filebrowserplus_port,
+                "-m conntrack --ctstate ESTABLISHED -j ACCEPT"))
+        end
     else
         logger.info("[FilebrowserPlus] Failed to stop Filebrowser, status:", status)
         UIManager:show(InfoMessage:new{
             icon = "notice-warning",
-            text = _("Failed to stop Filebrowser.")
+            timeout = 15,
+            text = _("Failed to stop Filebrowser")
         })
     end
 
-    
 end
 
 function FilebrowserPlus:onToggleFilebrowserPlusServer()
@@ -334,80 +381,162 @@ function FilebrowserPlus:show_dataPath_dialog(touchmenu_instance)
     self.dataPath_dialog:onShowKeyboard()
 end
 
+function FilebrowserPlus:getIPAddress()
+    if Device.retrieveNetworkInfo then
+        local net_info = Device:retrieveNetworkInfo()
+        if type(net_info) == "table" and net_info.ip then
+            return net_info.ip
+        elseif type(net_info) == "string" then
+            return net_info:match("(%d+%.%d+%.%d+%.%d+)") or nil
+        end
+    end
+    return nil
+end
+
+function FilebrowserPlus:show_autostop_dialog(touchmenu_instance)
+    self.autostop_dialog = InputDialog:new{
+        title = _("Auto-stop timeout (min)"),
+        description = _("Set to 0 to disable"),
+        input = tostring(self.auto_stop_minutes),
+        input_type = "number",
+        buttons = {{{
+            text = _("Cancel"),
+            id = "close",
+            callback = function()
+                UIManager:close(self.autostop_dialog)
+            end
+        }, {
+            text = _("Save"),
+            is_enter_default = true,
+            callback = function()
+                local value = tonumber(self.autostop_dialog:getInputText())
+                if value and value >= 0 then
+                    self.auto_stop_minutes = value
+                    G_reader_settings:saveSetting("FilebrowserPlus_auto_stop_minutes", value)
+                    UIManager:close(self.autostop_dialog)
+                    touchmenu_instance:updateItems()
+                end
+            end
+        }}}
+    }
+    UIManager:show(self.autostop_dialog)
+    self.autostop_dialog:onShowKeyboard()
+end
+
 function FilebrowserPlus:addToMainMenu(menu_items)
+    local sub_item_table = {{
+        text_func = function()
+            return T(_("FilebrowserPlus port (%1)"), self.filebrowserplus_port)
+        end,
+        keep_menu_open = true,
+        enabled_func = function()
+            return not self:isRunning()
+        end,
+        callback = function(touchmenu_instance)
+            self:show_port_dialog(touchmenu_instance)
+        end
+    }, {
+        text_func = function()
+            return T(_("FilebrowserPlus Data Path (%1)"), self.filebrowserplus_dataPath)
+        end,
+        keep_menu_open = true,
+        enabled_func = function()
+            return not self:isRunning()
+        end,
+        callback = function(touchmenu_instance)
+            self:show_dataPath_dialog(touchmenu_instance)
+        end
+    }, {
+        text = _("Reset Admin User Password"),
+        keep_menu_open = true,
+        enabled_func = function()
+            return not self:isRunning()
+        end,
+        callback = function(touchmenu_instance)
+            self:resetPassword()
+        end
+    }, {
+        text = _("Login without password (DANGEROUS)"),
+        checked_func = function()
+            return self.allow_no_password
+        end,
+        enabled_func = function()
+            return not self:isRunning()
+        end,
+        callback = function()
+            self.allow_no_password = not self.allow_no_password
+            G_reader_settings:flipNilOrFalse("FilebrowserPlus_allow_no_password")
+        end
+    }, {
+        text = _("Start FilebrowserPlus server with KOReader"),
+        checked_func = function()
+            return self.autostart
+        end,
+        enabled_func = function()
+            return not self:isRunning()
+        end,
+        callback = function()
+            self.autostart = not self.autostart
+            G_reader_settings:flipNilOrFalse("FilebrowserPlus_autostart")
+        end
+    }, {
+        text_func = function()
+            if self.auto_stop_minutes and self.auto_stop_minutes > 0 then
+                return T(_("Auto-stop timeout (%1 min)"), self.auto_stop_minutes)
+            else
+                return _("Auto-stop timeout (disabled)")
+            end
+        end,
+        keep_menu_open = true,
+        enabled_func = function()
+            return not self:isRunning()
+        end,
+        callback = function(touchmenu_instance)
+            self:show_autostop_dialog(touchmenu_instance)
+        end
+    }}
+
     menu_items.filebrowserplus = {
-        text = _("FilebrowserPlus"),
+        text_func = function()
+            if self:isRunning() then
+                local ip = self:getIPAddress()
+                if ip then
+                    return T(_("FilebrowserPlus (%1:%2)"), ip, self.filebrowserplus_port)
+                else
+                    return T(_("FilebrowserPlus (:%1)"), self.filebrowserplus_port)
+                end
+
+            else
+                return _("FilebrowserPlus (Long press for settings)")
+            end
+        end,
         sorting_hint = "network",
         keep_menu_open = true,
-        sub_item_table = {{
-            text = _("FilebrowserPlus server"),
-            checked_func = function()
-                return self:isRunning()
-            end,
-            check_callback_updates_menu = true,
-            callback = function(touchmenu_instance)
-                self:onToggleFilebrowserPlusServer()
-                -- sleeping might not be needed, but it gives the feeling
-                -- something has been done and feedback is accurate
-                ffiutil.sleep(1)
-                touchmenu_instance:updateItems()
+        checked_func = function()
+            return self:isRunning()
+        end,
+        callback = function(touchmenu_instance)
+            self:onToggleFilebrowserPlusServer()
+            ffiutil.sleep(1)
+            touchmenu_instance:updateItems()
+        end,
+        hold_keep_menu_open = true,
+        hold_callback = function(touchmenu_instance)
+            local dummy_item = {
+                text = _("FilebrowserPlus settings"),
+                sub_item_table = sub_item_table
+            }
+            if touchmenu_instance.onMenuSelect then
+                touchmenu_instance:onMenuSelect(dummy_item)
+            else
+                local submenu = TouchMenu:new{
+                    title = _("FilebrowserPlus settings"),
+                    item_table = sub_item_table,
+                    parent = touchmenu_instance,
+                }
+                UIManager:show(submenu)
             end
-        }, {
-            text_func = function()
-                return T(_("FilebrowserPlus port (%1)"), self.filebrowserplus_port)
-            end,
-            keep_menu_open = true,
-            enabled_func = function()
-                return not self:isRunning()
-            end,
-            callback = function(touchmenu_instance)
-                self:show_port_dialog(touchmenu_instance)
-            end
-        }, {
-            text_func = function()
-                return T(_("FilebrowserPlus Data Path (%1)"), self.filebrowserplus_dataPath)
-            end,
-            keep_menu_open = true,
-            enabled_func = function()
-                return not self:isRunning()
-            end,
-            callback = function(touchmenu_instance)
-                self:show_dataPath_dialog(touchmenu_instance)
-            end
-        }, {
-            text = _("Reset Admin User Password"),
-            keep_menu_open = true,
-            enabled_func = function()
-                return not self:isRunning()
-            end,
-            callback = function(touchmenu_instance)
-                self:resetPassword()
-            end
-        }, {
-            text = _("Login without password (DANGEROUS)"),
-            checked_func = function()
-                return self.allow_no_password
-            end,
-            enabled_func = function()
-                return not self:isRunning()
-            end,
-            callback = function()
-                self.allow_no_password = not self.allow_no_password
-                G_reader_settings:flipNilOrFalse("FilebrowserPlus_allow_no_password")
-            end
-        }, {
-            text = _("Start FilebrowserPlus server with KOReader"),
-            checked_func = function()
-                return self.autostart
-            end,
-            enabled_func = function()
-                return not self:isRunning()
-            end,
-            callback = function()
-                self.autostart = not self.autostart
-                G_reader_settings:flipNilOrFalse("FilebrowserPlus_autostart")
-            end
-        }}
+        end
     }
 end
 

--- a/main.lua
+++ b/main.lua
@@ -24,7 +24,7 @@ local plugin_path = path .. "/plugins/filebrowserplus.koplugin/filebrowser"
 local silence_cmd = ""
 -- uncomment below to prevent cmd output from cluttering up crash.log
 silence_cmd = " > /dev/null 2>&1"
-local pid_path = "/tmp/filebrowserplus_koreader.pid"
+local pid_path = path .. "/filebrowserplus_koreader.pid"
 local bin_path = plugin_path .. "/filebrowser"
 
 local filebrowser_args = string.format("-d %s -c %s ", db_path, config_path)
@@ -39,6 +39,52 @@ if not util.pathExists(bin_path) then
 elseif os.execute("test -x '" .. bin_path .. "'") ~= 0 then
     logger.info("[FilebrowserPlus] binary not executable, attempting to fix permissions")
     os.execute("chmod +x " .. bin_path)
+end
+
+-- On Android, /sdcard is mounted noexec so the binary cannot be executed in-place
+-- regardless of its permission bits. Copy it to the app's internal files directory
+-- (/data/data/<pkg>/files) which is on the exec-capable /data partition.
+if Device:isAndroid() then
+    local function android_files_dir()
+        -- /proc/self/cmdline starts with the package name (null-terminated) on Android.
+        local f = io.open("/proc/self/cmdline", "rb")
+        if not f then return nil end
+        local pkg = f:read("*a"):match("^([^%z]+)")
+        f:close()
+        if not pkg or pkg == "" then return nil end
+        -- Primary path; on Android 8+ this is usually a symlink to /data/user/0/<pkg>
+        local dir = "/data/data/" .. pkg .. "/files"
+        if os.execute(string.format("test -d %q", dir)) == 0 then
+            return dir
+        end
+        -- Explicit multi-user path for the default user (user 0)
+        dir = "/data/user/0/" .. pkg .. "/files"
+        if os.execute(string.format("test -d %q", dir)) == 0 then
+            return dir
+        end
+        return nil
+    end
+
+    local exec_dir = android_files_dir() or "/data/local/tmp"
+    local android_bin = exec_dir .. "/filebrowserplus"
+
+    local function _fsize(p)
+        local f = io.open(p, "rb")
+        if not f then return nil end
+        local sz = f:seek("end")
+        f:close()
+        return sz
+    end
+
+    if _fsize(bin_path) ~= _fsize(android_bin) then
+        logger.info("[FilebrowserPlus] Copying binary to " .. exec_dir .. " (Android noexec workaround)")
+        os.execute(string.format("mkdir -p %q && cp %q %q && chmod +x %q",
+            exec_dir, bin_path, android_bin, android_bin))
+    elseif os.execute(string.format("test -x %q", android_bin)) ~= 0 then
+        os.execute(string.format("chmod +x %q", android_bin))
+    end
+    bin_path = android_bin
+    filebrowser_cmd = bin_path .. " " .. filebrowser_args
 end
 
 local FilebrowserPlus = WidgetContainer:extend{
@@ -175,7 +221,10 @@ function FilebrowserPlus:start()
         os.execute(enable_auth_cmd)
     end
 
-    local cmd = string.format("nohup %q -a 0.0.0.0 -r %q -p %s -l %q %s & echo $! > %q", bin_path,
+    -- > /dev/null 2>&1 before the & prevents the backgrounded process from
+    -- inheriting the pipe that os.execute() reads, which would cause KOReader
+    -- to block indefinitely waiting for the pipe to close.
+    local cmd = string.format("nohup %q -a 0.0.0.0 -r %q -p %s -l %q %s > /dev/null 2>&1 & echo $! > %q", bin_path,
         self.filebrowserplus_dataPath, self.filebrowserplus_port, log_path, filebrowser_args, pid_path)
 
     logger.info("[FilebrowserPlus] Launching Filebrowser:", cmd)
@@ -387,8 +436,17 @@ function FilebrowserPlus:getIPAddress()
         if type(net_info) == "table" and net_info.ip then
             return net_info.ip
         elseif type(net_info) == "string" then
-            return net_info:match("(%d+%.%d+%.%d+%.%d+)") or nil
+            local ip = net_info:match("(%d+%.%d+%.%d+%.%d+)")
+            if ip then return ip end
         end
+    end
+    -- Fallback: ask the kernel which source address it would use to reach the
+    -- internet. Works reliably on Android where retrieveNetworkInfo may be absent.
+    local f = io.popen("ip route get 1 2>/dev/null")
+    if f then
+        local route = f:read("*a")
+        f:close()
+        return route:match("src%s+(%d+%.%d+%.%d+%.%d+)") or nil
     end
     return nil
 end


### PR DESCRIPTION
Hi. I don't know how to program but Claude helped me do this. Sorry if it's AI slop.
I couldn't get this plugin to work on my android-based Nook Glowlight 4 plus. There were some android permission issues about exec'ing from /sdcard and other random things. 

Anyway, it works great on my GL4plus so thanks for making it. It hopefully wouldn't have strange effects on other devices.

## Summary

Fixes four issues that prevent the plugin from running on Android (tested on Nook Glowlight 4 Plus, Android 8.1.0 / `org.koreader.launcher`).

### 1. noexec workaround
Android mounts `/sdcard` with the `noexec` flag, so the binary cannot be executed from the plugin directory regardless of `chmod`. At startup the binary is now copied to the app's internal files directory (`/data/data/<pkg>/files`), derived from `/proc/self/cmdline`, which is on the exec-capable `/data` partition. Falls back to `/data/local/tmp` if the internal path is unavailable. The copy is skipped when the destination already exists with the same file size.

### 2. PID file path
`/tmp` does not exist on Android. Changed `pid_path` to use the KOReader data directory (`path`), which is writable on all platforms. Without this the server starts but KOReader shows a failure toast and the checkbox stays unchecked.

### 3. nohup pipe freeze
KOReader's `os.execute()` captures stdout/stderr via a pipe. The backgrounded filebrowser inherited the pipe's write end, keeping it open and causing KOReader to block indefinitely (frozen UI). Fixed by redirecting the process output to `/dev/null` before the `&` in the launch command (`> /dev/null 2>&1 &`).

### 4. IP address detection
`Device:retrieveNetworkInfo()` is not implemented on Android. Added a fallback in `getIPAddress()` using `ip route get 1`, which asks the kernel for the primary outbound source address and works reliably regardless of interface name.

## Test plan

- [ ] Plugin loads without errors on Android (KOReader logcat shows no Lua errors)
- [ ] Binary is copied to `/data/data/org.koreader.launcher/files/filebrowserplus` on first run
- [ ] Toggling the server on does not freeze KOReader
- [ ] Checkbox reflects running state correctly
- [ ] Menu title shows IP address and port when server is running
- [ ] Server is reachable from browser on the same network

🤖 Generated with [Claude Code](https://claude.com/claude-code)